### PR TITLE
Google Maps API Reverse Geolocation

### DIFF
--- a/google.geocoding.client/Google.Geocoding.Client.Console/App.config
+++ b/google.geocoding.client/Google.Geocoding.Client.Console/App.config
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" />
+  </startup>
+</configuration>

--- a/google.geocoding.client/Google.Geocoding.Client.Console/Google.Geocoding.Client.Console.csproj
+++ b/google.geocoding.client/Google.Geocoding.Client.Console/Google.Geocoding.Client.Console.csproj
@@ -1,0 +1,59 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{060E1D2F-EAA8-4812-A64A-2A0F9718C561}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Google.Geocoding.Client.Console</RootNamespace>
+    <AssemblyName>Google.Geocoding.Client.Console</AssemblyName>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Google.Geocoding.Client\Google.Geocoding.Client.csproj">
+      <Project>{c8125ed5-0828-4de2-bdd2-4824100b14de}</Project>
+      <Name>Google.Geocoding.Client</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/google.geocoding.client/Google.Geocoding.Client.Console/Program.cs
+++ b/google.geocoding.client/Google.Geocoding.Client.Console/Program.cs
@@ -1,0 +1,90 @@
+﻿namespace Google.Geocoding.Client.Console
+{
+    using System;
+    using System.Globalization;
+
+    /// <summary>
+    /// An application that looks up geolocation data by latitude and longitude. This class cannot be inherited.
+    /// </summary>
+    internal static class Program
+    {
+        /// <summary>
+        /// The main entry-point to the application.
+        /// </summary>
+        /// <param name="args">The arguments passed to the application.</param>
+        internal static void Main(string[] args)
+        {
+            var client = new GeocodingClient();
+
+            if (args != null && args.Length == 1)
+            {
+                client.ApiKey = args[0];
+            }
+
+            string coordinates = null;
+
+            while (true)
+            {
+                Console.Write("Coordinates: ");
+                coordinates = Console.ReadLine();
+
+                if (string.IsNullOrEmpty(coordinates))
+                {
+                    break;
+                }
+
+                string[] parts = coordinates.Split(',');
+
+                if (parts.Length != 2)
+                {
+                    continue;
+                }
+
+                double latitude;
+                double longitude;
+
+                if (!double.TryParse(parts[0].Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out latitude))
+                {
+                    continue;
+                }
+
+                if (!double.TryParse(parts[1].Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out longitude))
+                {
+                    continue;
+                }
+
+                CoordinateLookup result;
+
+                try
+                {
+                    result = client.LookupAsync(latitude, longitude).Result;
+                }
+                catch (Exception ex)
+                {
+                    Console.Error.WriteLine();
+                    Console.Error.WriteLine("Failed to look up coordinates: {0}", ex.ToString());
+                    continue;
+                }
+
+                Console.WriteLine();
+                Console.WriteLine("Result for {0}:", coordinates);
+                Console.WriteLine();
+
+                if (result == null)
+                {
+                    Console.WriteLine("  Not found.");
+                }
+                else
+                {
+                    Console.WriteLine("     Lat/Long: {0:N2},{1:N2}", latitude, longitude);
+                    Console.WriteLine("         City: {0}", result.City);
+                    Console.WriteLine("  Postal Code: {0}", result.PostalCode);
+                    Console.WriteLine("       Region: {0}", result.RegionCode);
+                    Console.WriteLine("      Country: {0}", result.CountryCode);
+                }
+
+                Console.WriteLine();
+            }
+        }
+    }
+}

--- a/google.geocoding.client/Google.Geocoding.Client.Console/Properties/AssemblyInfo.cs
+++ b/google.geocoding.client/Google.Geocoding.Client.Console/Properties/AssemblyInfo.cs
@@ -1,0 +1,35 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Google.Geocoding.Client.Console")]
+[assembly: AssemblyDescription("Console application for Google.Geocoding.Client.")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Experian")]
+[assembly: AssemblyProduct("EDQ HackDay 2015")]
+[assembly: AssemblyCopyright("Copyright © Experian, 2015. All rights reserved.")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("060e1d2f-eaa8-4812-a64a-2a0f9718c561")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/google.geocoding.client/Google.Geocoding.Client.sln
+++ b/google.geocoding.client/Google.Geocoding.Client.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.23107.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Geocoding.Client", "Google.Geocoding.Client\Google.Geocoding.Client.csproj", "{C8125ED5-0828-4DE2-BDD2-4824100B14DE}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Geocoding.Client.Console", "Google.Geocoding.Client.Console\Google.Geocoding.Client.Console.csproj", "{060E1D2F-EAA8-4812-A64A-2A0F9718C561}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{C8125ED5-0828-4DE2-BDD2-4824100B14DE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C8125ED5-0828-4DE2-BDD2-4824100B14DE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C8125ED5-0828-4DE2-BDD2-4824100B14DE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C8125ED5-0828-4DE2-BDD2-4824100B14DE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{060E1D2F-EAA8-4812-A64A-2A0F9718C561}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{060E1D2F-EAA8-4812-A64A-2A0F9718C561}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{060E1D2F-EAA8-4812-A64A-2A0F9718C561}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{060E1D2F-EAA8-4812-A64A-2A0F9718C561}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/google.geocoding.client/Google.Geocoding.Client/CoordinateLookup.cs
+++ b/google.geocoding.client/Google.Geocoding.Client/CoordinateLookup.cs
@@ -1,0 +1,28 @@
+﻿namespace Google.Geocoding.Client
+{
+    /// <summary>
+    /// A class representing the result of looking up the address for a latitude and longitude using the Google Maps Geocoding API.
+    /// </summary>
+    public class CoordinateLookup
+    {
+        /// <summary>
+        /// Gets or sets the country code associated with the coordinates.
+        /// </summary>
+        public string CountryCode { get; set; }
+
+        /// <summary>
+        /// Gets or sets the region code associated with the coordinates.
+        /// </summary>
+        public string RegionCode { get; set; }
+
+        /// <summary>
+        /// Gets or sets the city associated with the coordinates.
+        /// </summary>
+        public string City { get; set; }
+
+        /// <summary>
+        /// Gets or sets the postal code associated with the coordinates.
+        /// </summary>
+        public string PostalCode { get; set; }
+    }
+}

--- a/google.geocoding.client/Google.Geocoding.Client/GeocodingClient.cs
+++ b/google.geocoding.client/Google.Geocoding.Client/GeocodingClient.cs
@@ -1,0 +1,132 @@
+﻿namespace Google.Geocoding.Client
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.Linq;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// A class representing a client for the Google Maps geocoding API.
+    /// </summary>
+    public class GeocodingClient
+    {
+        /// <summary>
+        /// Initializes a new instance of <see cref="GeocodingClient"/>.
+        /// </summary>
+        public GeocodingClient()
+        {
+            ApiKey = Environment.GetEnvironmentVariable("Google_ApiKey");
+        }
+
+        /// <summary>
+        /// Gets or sets the API key to use.
+        /// </summary>
+        public string ApiKey { get; set; }
+
+        /// <summary>
+        /// Looks up the geolocation information associated with the specified latitude and longitude as an asynchronous operation.
+        /// </summary>
+        /// <param name="latitude">The latitude.</param>
+        /// <param name="longitude">The longitude.</param>
+        /// <returns>
+        /// A <see cref="Task{TResult}"/> representing the result of looking up the specified latitude and longitude.
+        /// </returns>
+        public async Task<CoordinateLookup> LookupAsync(double latitude, double longitude)
+        {
+            string requestUri = string.Format(
+                CultureInfo.InvariantCulture,
+                "https://maps.googleapis.com/maps/api/geocode/json?latlng={0},{1}&key={2}",
+                latitude,
+                longitude,
+                Uri.EscapeDataString(ApiKey ?? string.Empty));
+
+            CoordinateLookup result = null;
+
+            using (var client = new HttpClient())
+            {
+                using (var response = await client.GetAsync(requestUri))
+                {
+                    response.EnsureSuccessStatusCode();
+
+                    var lookup = await response.Content.ReadAsAsync<GeocodeResult>();
+
+                    if (lookup != null && lookup.Results.Count > 0)
+                    {
+                        var item = lookup.Results.First();
+
+                        result = new CoordinateLookup()
+                        {
+                            City = GetShortName(item, "sublocality_level_1"),
+                            CountryCode = GetShortName(item, "country"),
+                            PostalCode = GetShortName(item, "postal_code"),
+                            RegionCode = GetShortName(item, "administrative_area_level_1"),
+                        };
+
+                        if (string.IsNullOrEmpty(result.City))
+                        {
+                            result.City = GetShortName(item, "postal_town");
+                        }
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Gets the short name of the address component with the specified name, if found.
+        /// </summary>
+        /// <param name="value">The value to get the component's short name from.</param>
+        /// <param name="componentName">The name of the component to get the short name of.</param>
+        /// <returns>
+        /// A <see cref="string"/> containing the short name of the specified component, if found.
+        /// </returns>
+        private static string GetShortName(GeocodeResultItem value, string componentName)
+        {
+            return value.AddressComponents
+                .Where((p) => p.Types.Contains(componentName))
+                .Select((p) => p.ShortName)
+                .DefaultIfEmpty(string.Empty)
+                .FirstOrDefault();
+        }
+
+        private sealed class GeocodeResult
+        {
+            [JsonProperty("results")]
+            public ICollection<GeocodeResultItem> Results { get; set; }
+
+            [JsonProperty("status")]
+            public string Status { get; set; }
+        }
+
+        private sealed class GeocodeResultItem
+        {
+            [JsonProperty("address_components")]
+            public ICollection<AddressComponent> AddressComponents { get; set; }
+
+            [JsonProperty("formatted_address")]
+            public string FormattedAddress { get; set; }
+
+            [JsonProperty("place_id")]
+            public string PlaceId { get; set; }
+
+            [JsonProperty("types")]
+            public ICollection<string> Types { get; set; }
+        }
+
+        private sealed class AddressComponent
+        {
+            [JsonProperty("long_name")]
+            public string LongName { get; set; }
+
+            [JsonProperty("short_name")]
+            public string ShortName { get; set; }
+
+            [JsonProperty("types")]
+            public ICollection<string> Types { get; set; }
+        }
+    }
+}

--- a/google.geocoding.client/Google.Geocoding.Client/Google.Geocoding.Client.csproj
+++ b/google.geocoding.client/Google.Geocoding.Client/Google.Geocoding.Client.csproj
@@ -1,0 +1,63 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{C8125ED5-0828-4DE2-BDD2-4824100B14DE}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Google.Geocoding.Client</RootNamespace>
+    <AssemblyName>Google.Geocoding.Client</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Debug\Google.Geocoding.Client.xml</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Release\Google.Geocoding.Client.xml</DocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Net.Http" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="CoordinateLookup.cs" />
+    <Compile Include="GeocodingClient.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/google.geocoding.client/Google.Geocoding.Client/Properties/AssemblyInfo.cs
+++ b/google.geocoding.client/Google.Geocoding.Client/Properties/AssemblyInfo.cs
@@ -1,0 +1,35 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Google.Geocoding.Client")]
+[assembly: AssemblyDescription("Google Maps Geocoding API client.")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Experian")]
+[assembly: AssemblyProduct("EDQ HackDay 2015")]
+[assembly: AssemblyCopyright("Copyright © Experian, 2015. All rights reserved.")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("c8125ed5-0828-4de2-bdd2-4824100b14de")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/google.geocoding.client/Google.Geocoding.Client/app.config
+++ b/google.geocoding.client/Google.Geocoding.Client/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/google.geocoding.client/Google.Geocoding.Client/packages.config
+++ b/google.geocoding.client/Google.Geocoding.Client/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
+</packages>

--- a/postalcodefinder/postalcodefinder.sln
+++ b/postalcodefinder/postalcodefinder.sln
@@ -13,6 +13,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FreeGeoIP.Client", "..\free
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VisitorIQ.Client", "..\visitoriq.client\VisitorIQ.Client\VisitorIQ.Client.csproj", "{F059C3B6-7505-491B-BFEE-40DAF56F7758}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Geocoding.Client", "..\google.geocoding.client\Google.Geocoding.Client\Google.Geocoding.Client.csproj", "{C8125ED5-0828-4DE2-BDD2-4824100B14DE}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -35,6 +37,10 @@ Global
 		{F059C3B6-7505-491B-BFEE-40DAF56F7758}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F059C3B6-7505-491B-BFEE-40DAF56F7758}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F059C3B6-7505-491B-BFEE-40DAF56F7758}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C8125ED5-0828-4DE2-BDD2-4824100B14DE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C8125ED5-0828-4DE2-BDD2-4824100B14DE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C8125ED5-0828-4DE2-BDD2-4824100B14DE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C8125ED5-0828-4DE2-BDD2-4824100B14DE}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/postalcodefinder/postalcodefinder/Controllers/LocationController.cs
+++ b/postalcodefinder/postalcodefinder/Controllers/LocationController.cs
@@ -34,7 +34,7 @@
                     return BadRequest("Invalid longitude specified.");
                 }
 
-                response = LookupByCoordinates(value.Coordinates);
+                response = await LookupByCoordinatesAsync(value.Coordinates);
             }
             else if (value.Timestamp.HasValue)
             {
@@ -48,24 +48,32 @@
             return Ok(response);
         }
 
-        private static LocationReponse LookupByCoordinates(LocationRequest.LocationCoordinates coordinates)
+        private static async Task<LocationReponse> LookupByCoordinatesAsync(LocationRequest.LocationCoordinates coordinates)
         {
-            // TODO Do proper lookup by latitude and longitude
             string country = string.Empty;
             string region = string.Empty;
             string postalCode = string.Empty;
+            string city = string.Empty;
 
-            if (coordinates.Latitude > 48.0 && coordinates.Latitude < 59.0 &&
-                coordinates.Longitude > -5.0 && coordinates.Longitude < 2.0)
+            var client = new Google.Geocoding.Client.GeocodingClient()
             {
-                country = "GB";
-                region = "ENG";
-                postalCode = "SW11";
+                ApiKey = ConfigurationManager.AppSettings["Google_ApiKey"],
+            };
+
+            var lookup = await client.LookupAsync(coordinates.Latitude, coordinates.Longitude);
+
+            if (lookup != null)
+            {
+                city = lookup.City;
+                country = lookup.CountryCode;
+                region = lookup.RegionCode;
+                postalCode = lookup.PostalCode;
             }
 
             return new LocationReponse()
             {
                 DerivationMethod = "coordinates",
+                City = city,
                 Country = country,
                 PostalCode = postalCode,
                 Region = region,
@@ -101,6 +109,7 @@
             return new LocationReponse()
             {
                 DerivationMethod = "ipAddress",
+                City = string.Empty,
                 Country = string.Empty,
                 PostalCode = string.Empty,
                 Region = string.Empty,
@@ -128,6 +137,7 @@
                     return new LocationReponse()
                     {
                         DerivationMethod = "ipAddress",
+                        City = location.City,
                         Country = location.CountryCode,
                         PostalCode = location.PostalCode,
                         Region = location.RegionCode,
@@ -144,6 +154,7 @@
                     return new LocationReponse()
                     {
                         DerivationMethod = "ipAddress",
+                        City = location.City,
                         Country = location.CountryCode,
                         PostalCode = location.PostalCode,
                         Region = location.RegionCode,
@@ -159,35 +170,41 @@
             string country = "GB";
             string region = "ENG";
             string postalCode = "SW11";
+            string city = string.Empty;
 
             if (value.Offset == TimeSpan.FromHours(-5))
             {
                 country = "US";
                 region = "NY";
                 postalCode = "10547";
+                city = "Mohegan Lake";
             }
             else if (value.Offset == TimeSpan.FromHours(-6))
             {
                 country = "US";
                 region = "TX";
                 postalCode = "75155";
+                city = "Rice";
             }
             else if (value.Offset == TimeSpan.FromHours(-7))
             {
                 country = "US";
                 region = "CO";
                 postalCode = "80208";
+                city = "Denver";
             }
             else if (value.Offset == TimeSpan.FromHours(-8))
             {
                 country = "US";
                 region = "WA";
                 postalCode = "98009";
+                city = "Bellevue";
             }
 
             return new LocationReponse()
             {
                 DerivationMethod = "timestamp",
+                City = city,
                 Country = country,
                 PostalCode = postalCode,
                 Region = region,

--- a/postalcodefinder/postalcodefinder/Models/LocationReponse.cs
+++ b/postalcodefinder/postalcodefinder/Models/LocationReponse.cs
@@ -13,6 +13,9 @@ namespace postalcodefinder.Models
         [JsonProperty("postalCode")]
         public string PostalCode { get; set; }
 
+        [JsonProperty("city")]
+        public string City { get; set; }
+
         [JsonProperty("derivationMethod")]
         public string DerivationMethod { get; set; }
     }

--- a/postalcodefinder/postalcodefinder/postalcodefinder.csproj
+++ b/postalcodefinder/postalcodefinder/postalcodefinder.csproj
@@ -261,6 +261,10 @@
       <Project>{9e5eefba-992b-422e-a919-1c7c2efcd63c}</Project>
       <Name>FreeGeoIP.Client</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\google.geocoding.client\Google.Geocoding.Client\Google.Geocoding.Client.csproj">
+      <Project>{c8125ed5-0828-4de2-bdd2-4824100b14de}</Project>
+      <Name>Google.Geocoding.Client</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\visitoriq.client\VisitorIQ.Client\VisitorIQ.Client.csproj">
       <Project>{f059c3b6-7505-491b-bfee-40daf56f7758}</Project>
       <Name>VisitorIQ.Client</Name>


### PR DESCRIPTION
Adds use of the Google Maps Gelocation API to get the address associated with a latitude and longitude. Also adds `city` to the response from `POST /api/location`.
