### PR TITLE
Enable SQL Geospatial Queries

### DIFF
--- a/postalcodefinder/postalcodefinder/Controllers/LocationController.cs
+++ b/postalcodefinder/postalcodefinder/Controllers/LocationController.cs
@@ -29,7 +29,7 @@
 
             if (value.Coordinates != null)
             {
-                if (value.Coordinates.Latitude > 90.0 || value.Coordinates.Longitude < -90.0)
+                if (value.Coordinates.Latitude > 90.0 || value.Coordinates.Latitude < -90.0)
                 {
                     return BadRequest("Invalid latitude specified.");
                 }

--- a/postalcodefinder/postalcodefinder/Controllers/LocationController.cs
+++ b/postalcodefinder/postalcodefinder/Controllers/LocationController.cs
@@ -3,6 +3,8 @@
     using System;
     using System.ComponentModel.DataAnnotations;
     using System.Configuration;
+    using System.Data.SqlClient;
+    using System.Globalization;
     using System.Net.Http;
     using System.Threading.Tasks;
     using System.Web;
@@ -57,19 +59,69 @@
             string postalCode = string.Empty;
             string city = string.Empty;
 
-            var client = new Google.Geocoding.Client.GeocodingClient()
-            {
-                ApiKey = ConfigurationManager.AppSettings["Google_ApiKey"],
-            };
+            var connectionString = ConfigurationManager.ConnectionStrings["SqlAzure"];
 
-            var lookup = await client.LookupAsync(coordinates.Latitude, coordinates.Longitude);
-
-            if (lookup != null)
+            if (connectionString != null && !string.IsNullOrEmpty(connectionString.ConnectionString))
             {
-                city = lookup.City;
-                country = lookup.CountryCode;
-                region = lookup.RegionCode;
-                postalCode = lookup.PostalCode;
+                using (var connection = new SqlConnection(connectionString.ConnectionString))
+                {
+                    await connection.OpenAsync();
+
+                    try
+                    {
+                        using (var command = connection.CreateCommand())
+                        {
+                            command.Parameters.Add(new SqlParameter("@lat", coordinates.Latitude));
+                            command.Parameters.Add(new SqlParameter("@long", coordinates.Longitude));
+
+                            command.CommandText = @"
+declare @g geography = geography::Point(@lat, @long, 4326)
+
+select top 1 [Iso2],
+             [PostalCode],
+             [PlaceName],
+             [StateCode]
+from [dbo].[tblGB]
+where [GeoLocation].STDistance(@g) is not null
+order by [GeoLocation].STDistance(@g);
+";
+
+                            using (var reader = await command.ExecuteReaderAsync())
+                            {
+                                while (await reader.ReadAsync())
+                                {
+                                    city = Convert.ToString(reader["PlaceName"], CultureInfo.InvariantCulture);
+                                    country = Convert.ToString(reader["Iso2"], CultureInfo.InvariantCulture);
+                                    postalCode = Convert.ToString(reader["PostalCode"], CultureInfo.InvariantCulture);
+                                    region = Convert.ToString(reader["StateCode"], CultureInfo.InvariantCulture);
+
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    finally
+                    {
+                        connection.Close();
+                    }
+                }
+            }
+            else
+            {
+                var client = new Google.Geocoding.Client.GeocodingClient()
+                {
+                    ApiKey = ConfigurationManager.AppSettings["Google_ApiKey"],
+                };
+
+                var lookup = await client.LookupAsync(coordinates.Latitude, coordinates.Longitude);
+
+                if (lookup != null)
+                {
+                    city = lookup.City;
+                    country = lookup.CountryCode;
+                    region = lookup.RegionCode;
+                    postalCode = lookup.PostalCode;
+                }
             }
 
             return new LocationReponse()

--- a/postalcodefinder/postalcodefinder/Web.Release.config
+++ b/postalcodefinder/postalcodefinder/Web.Release.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0"?>
 <configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
   <connectionStrings>
-    <add name="AzureStorage" connectionString="" xdt:Transform="Remove" xdt:Locator="Match(name)"/>
+    <add name="SqlAzure" connectionString="" xdt:Transform="Remove" xdt:Locator="Match(name)"/>
   </connectionStrings>
   <system.web>
     <compilation xdt:Transform="RemoveAttributes(debug)" />

--- a/postalcodefinder/postalcodefinder/Web.Release.config
+++ b/postalcodefinder/postalcodefinder/Web.Release.config
@@ -5,5 +5,9 @@
   </connectionStrings>
   <system.web>
     <compilation xdt:Transform="RemoveAttributes(debug)" />
+    <customErrors mode="On" xdt:Transform="Replace" />
   </system.web>
+  <system.webServer>
+    <httpErrors errorMode="Custom" xdt:Transform="Replace" />
+  </system.webServer>
 </configuration>

--- a/postalcodefinder/postalcodefinder/Web.config
+++ b/postalcodefinder/postalcodefinder/Web.config
@@ -11,7 +11,7 @@
   </appSettings>
   <connectionStrings>
     <clear />
-    <add name="AzureStorage" connectionString="UseDevelopmentStorage=true" />
+    <add name="SqlAzure" connectionString="" providerName="System.Data.SqlClient" />
   </connectionStrings>
   <postalcodefinder loadDataOnAppStart="false" /> 
   <system.web>

--- a/postalcodefinder/postalcodefinder/Web.config
+++ b/postalcodefinder/postalcodefinder/Web.config
@@ -16,7 +16,7 @@
   <postalcodefinder loadDataOnAppStart="false" /> 
   <system.web>
     <compilation debug="true" targetFramework="4.5" optimizeCompilations="false" />
-    <customErrors mode="Off" />
+    <customErrors mode="RemoteOnly" />
     <httpRuntime targetFramework="4.5" />
   </system.web>
   <system.webServer>
@@ -26,6 +26,7 @@
       <remove name="TRACEVerbHandler" />
       <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" />
     </handlers>
+    <httpErrors errorMode="DetailedLocalOnly" />
   </system.webServer>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">


### PR DESCRIPTION
If an SQL connection string is configured and a latitude and longitude is specified, then a geospatial query is performed on the database to find the nearest defined city/region/postal code/country to that latitude and longitude.

Also fixes incorrect parameter validation on coordinates and custom errors not being enabled.
